### PR TITLE
Allow custom API endpoint

### DIFF
--- a/modules/api/api.js
+++ b/modules/api/api.js
@@ -85,7 +85,7 @@ function drupalgap_api_default_options() {
 		'async':true,
 		'data':'',
 		'dataType':'json',
-		'endpoint':'drupalgap',
+		'endpoint':drupalgap.settings.endpoint || 'drupalgap',
 		'site_path':drupalgap.settings.site_path,
 		'success':function(result){
 			// TODO - this is a good spot for a hook


### PR DESCRIPTION
My site's setup on `{url}/rest` instead of `{url}/drupalgap` for some reasons. Allow custom API endpoint if specified, default to `drupalgap`
