### PR TITLE
Update common.inc.js

### DIFF
--- a/includes/common.inc.js
+++ b/includes/common.inc.js
@@ -205,7 +205,7 @@ function drupalgap_goto(path) {
     
     // Return if we are trying to go to the path we are already on, unless this
     // was a form submission, then we'll let the page rebuild itself
-    if (drupalgap.path == path && !options.form_submission) {
+    if ($.mobile.activePage.data('url') == path && !options.form_submission) {
       return false;
     }
     


### PR DESCRIPTION
The $.mobile.activePage.data('url') is more reliable than drupalgap.path, especially after a back button click. If you are on a full node, click back, then the drupalgap.path is wrong, still thinks you are on the node. $.mobile.activePage.data('url') has the correct path.

This is a fix for issue #64.
https://github.com/signalpoint/DrupalGap/issues/64
