### PR TITLE
Update drupalgap.js

### DIFF
--- a/drupalgap.js
+++ b/drupalgap.js
@@ -592,6 +592,9 @@ function drupalgap_image_path(uri) {
     if (src.indexOf('public://') != -1) {
       var src = src.replace('public://', drupalgap.settings.file_public_path + '/');
     }
+    else if (uri.indexOf('s3://') != -1) {
+      var src = uri.replace('s3://', drupalgap.settings.s3_public_path + '/');
+    }
     return src;
   }
   catch (error) {


### PR DESCRIPTION
Added support for images stored with Amazon S3 module.

You can define in settings.js, file_public_pat variable with the path to your cloudfront or bucket url.
Ex:
/\* Files */
  'file_public_path':'sites/default/files',
  's3_public_path':'http://museion.s3.amazonaws.com',

https://drupal.org/project/amazons3
"The AmazonS3 module allows the local file system to be replaced with S3. Uploads are saved into the drupal file table using D7's new file/stream wrapper system."
