### PR TITLE
Remove first 2 arguments that added before invocation to every module.

### DIFF
--- a/includes/module.inc.js
+++ b/includes/module.inc.js
@@ -109,6 +109,7 @@ function module_invoke_all(hook) {
                 module_arguments.unshift(module.name, hook);
                 var fn = window['module_invoke'];
                 invocation_results = fn.apply(null, module_arguments);
+                module_arguments.splice(0,2);
               }
               if (typeof invocation_results !== 'undefined') {
                 module_invoke_results.push(invocation_results);


### PR DESCRIPTION
The hook invocation with arguments has a problem when having more than 1 module implements the hook.
For example, the 'hook_form_alter', there was a implementation image_form_alter() created recently. This make our custom implementation 'my_module_form_alter' did not get the correct parameters.
