### PR TITLE
Blank page after clicking submit button.

### DIFF
--- a/includes/form.inc.js
+++ b/includes/form.inc.js
@@ -624,6 +624,7 @@ function _drupalgap_form_render_element_item(form, element, variables, item) {
       if (!variables.attributes['data-theme']) {
         variables.attributes['data-theme'] = 'b';
       }
+      variables.attributes.type = 'button';
     }
     
     // Merge the item into variables.


### PR DESCRIPTION
The submit button required an attribute type="button", otherwise the form will be redirected to blank page after submission.
