### PR TITLE
Add None option for non-required select fields

### DIFF
--- a/bin/drupalgap.js
+++ b/bin/drupalgap.js
@@ -7050,6 +7050,9 @@ function options_field_widget_form(form, form_state, field, instance, langcode,
         if (items[delta].required) {
           items[delta].options[-1] = 'Select';
           items[delta].value = -1;
+        } else if (instance.widget.type == 'options_select') {
+          items[delta].options[''] = 'None';
+          items[delta].value = '';
         }
         // If there are any allowed values, place them on the options list. Then
         // check for a default value, and set it if necessary.

--- a/src/modules/field/field.js
+++ b/src/modules/field/field.js
@@ -316,6 +316,9 @@ function options_field_widget_form(form, form_state, field, instance, langcode,
         if (items[delta].required) {
           items[delta].options[-1] = 'Select';
           items[delta].value = -1;
+        } else if (instance.widget.type == 'options_select') {
+          items[delta].options[''] = 'None';
+          items[delta].value = '';
         }
         // If there are any allowed values, place them on the options list. Then
         // check for a default value, and set it if necessary.


### PR DESCRIPTION
Referencing https://github.com/signalpoint/DrupalGap/issues/272

It fixed the issue for me. Selecting 'None' doesn't show up in the update/create request but selecting one of the other select options does.
