### PR TITLE
Add None option for non-required select fields

### DIFF
--- a/bin/drupalgap.js
+++ b/bin/drupalgap.js
@@ -7050,6 +7050,11 @@ function options_field_widget_form(form, form_state, field, instance, langcode,
         if (items[delta].required) {
           items[delta].options[-1] = 'Select';
           items[delta].value = -1;
+        } else if (instance.widget.type == 'options_select') {
+          items[delta].options[''] = 'None';
+          if (empty(items[delta].value)) {
+            items[delta].value = '';
+          }
         }
         // If there are any allowed values, place them on the options list. Then
         // check for a default value, and set it if necessary.

--- a/src/modules/field/field.js
+++ b/src/modules/field/field.js
@@ -316,6 +316,11 @@ function options_field_widget_form(form, form_state, field, instance, langcode,
         if (items[delta].required) {
           items[delta].options[-1] = 'Select';
           items[delta].value = -1;
+        } else if (instance.widget.type == 'options_select') {
+          items[delta].options[''] = 'None';
+          if (empty(items[delta].value)) {
+            items[delta].value = '';
+          }
         }
         // If there are any allowed values, place them on the options list. Then
         // check for a default value, and set it if necessary.


### PR DESCRIPTION
Referencing https://github.com/signalpoint/DrupalGap/issues/272

It fixed the issue of select fields always being required because there is no 'None' option. Selecting 'None' doesn't show up in the update/create request but selecting one of the other options does.

Sorry if you got another pull request. Thought all was fine because I'd just copied the couple lines above except with different values but it was overwriting any value that was already set in items[delta].value.
