### PR TITLE
make offline popup configurable

### DIFF
--- a/app/default.settings.js
+++ b/app/default.settings.js
@@ -44,6 +44,9 @@ drupalgap.settings.title = 'DrupalGap';
 // App Front Page
 drupalgap.settings.front = 'dashboard';
 
+// Offline warning message
+drupalgap.settings.offline_message = 'No connection found!';
+
 // Theme
 drupalgap.settings.theme = 'easystreet3';
 

--- a/bin/drupalgap.js
+++ b/bin/drupalgap.js
@@ -164,10 +164,15 @@ function _drupalgap_deviceready() {
     drupalgap_check_connection();
     if (!drupalgap.online) {
       module_invoke_all('device_offline');
-      drupalgap_alert('No connection found!', {
-          title: 'Offline',
-          alertCallback: function() { drupalgap_goto('offline'); }
-      });
+      if (drupalgap.settings.offline_message) {
+        drupalgap_alert(drupalgap.settings.offline_message, {
+            title: 'Offline',
+            alertCallback: function() { drupalgap_goto('offline'); }
+        });
+      }
+      else {
+        drupalgap_goto('offline');
+      }
       return;
     }
     else {

--- a/src/drupalgap.js
+++ b/src/drupalgap.js
@@ -164,10 +164,15 @@ function _drupalgap_deviceready() {
     drupalgap_check_connection();
     if (!drupalgap.online) {
       module_invoke_all('device_offline');
-      drupalgap_alert('No connection found!', {
-          title: 'Offline',
-          alertCallback: function() { drupalgap_goto('offline'); }
-      });
+      if (drupalgap.settings.offline_message) {
+        drupalgap_alert(drupalgap.settings.offline_message, {
+            title: 'Offline',
+            alertCallback: function() { drupalgap_goto('offline'); }
+        });
+      }
+      else {
+        drupalgap_goto('offline');
+      }
       return;
     }
     else {


### PR DESCRIPTION
as we discussed in IRC, the popup notification for when the app is started in offline mode could be made configurable.
The message can be set to false making the popup not appear at all.

The offline page can be overridden by implementing hook_menu and specifying a new offline page.
