### PR TITLE
The form validate does not need to be called until we are done processin...

### DIFF
--- a/src/includes/form.inc.js
+++ b/src/includes/form.inc.js
@@ -1173,15 +1173,15 @@ function _drupalgap_form_submit(form_id) {
       image_fields_present_on_entity_type(form.entity_type, form.bundle)
     ) {
       _image_field_form_process(form, form_state, {
-          success: form_validation
+          success: function() {
+            if (Drupal.settings.debug === true) {
+              console.log('_image_field_form_process - processed an image');
+            }
+          }
       });
     }
-    else {
-      // There were no image fields on the form, proceed normally with form
-      // validation, which will in turn process the submission if there are no
-      // validation errors.
-      form_validation();
-    }
+    // validate the form
+    form_validation();
   }
   catch (error) { console.log('_drupalgap_form_submit - ' + error); }
 }


### PR DESCRIPTION
The form validate does not need to be called until we are done processing all of the images; this fixes the multiple image fields on the node creating multiple nodes bug; still need to handle multiple images within an image field.
