### PR TITLE
Fixing issue with deferred image process for single occurring image fiel...

### DIFF
--- a/src/includes/form.inc.js
+++ b/src/includes/form.inc.js
@@ -1172,11 +1172,10 @@ function _drupalgap_form_submit(form_id) {
     if (form.entity_type &&
       image_fields_present_on_entity_type(form.entity_type, form.bundle)
     ) {
-      _image_field_form_process(form, form_state, {
-          success: form_validation
+      _image_fields_form_process(form, form_state, form_id, {
+         success: form_validation
       });
-    }
-    else {
+    } else {
       // There were no image fields on the form, proceed normally with form
       // validation, which will in turn process the submission if there are no
       // validation errors.


### PR DESCRIPTION
Fixing issue with deferred image process for single occurring image fields. Now all images are processed with jQuery Deferred() and when.done they options.success is fired. Still need to handle multiple images per field, but this gets us close and fixes the issue where multiple image fields on a form create multiple nodes; renamed local function _image_field_form_validate to _image_fields_form_validate to better describe its function.
