### PR TITLE
Merge adding support to allow app's langauge settings be applied during ...

### DIFF
--- a/src/modules/entity/entity.js
+++ b/src/modules/entity/entity.js
@@ -227,13 +227,20 @@ function drupalgap_entity_render_field(entity_type, entity, field_name,
       // to the entity's content.
       var fn = window[function_name];
       var items = null;
+      // Check to see if translated content based on app's language setting
+      // is present or not. If yes, then use that language as per setting.
       // Determine the language code. Note, multi lingual sites may have a
       // language code on the entity, but still have 'und' on the field, so
       // fall back to 'und' if the field's language code doesn't match the
       // entity's language code.
+
+      var default_lang = language_default();
       var language = entity.language;
       if (entity[field_name]) {
-        if (entity[field_name][language]) {
+        if (entity[field_name][default_lang]) {
+          items = entity[field_name][default_lang];
+        }
+        else if (entity[field_name][language]) {
           items = entity[field_name][language];
         }
         else if (entity[field_name]['und']) {

--- a/src/modules/node/node.js
+++ b/src/modules/node/node.js
@@ -248,12 +248,18 @@ function node_page_view_pageshow(nid) {
     node_load(nid, {
         success: function(node) {
           // Build the node display.
+          //For title the translation must be taken into account
+          var default_language = language_default();
+          var node_title = node.title;
+          if (node.title_field && node.title_field[default_language]) {
+                node_title = node.title_field[default_language][0].safe_value;
+          }
           var build = {
             'theme': 'node',
             // @todo - is this line of code doing anything?
             'node': node,
             // @todo - this is a core field and should by fetched from entity.js
-            'title': {'markup': node.title},
+            'title': {'markup': node_title},
             'content': {'markup': node.content}
           };
           // If the comments are closed (1) or open (2), show the comments.


### PR DESCRIPTION
Hi,

Currently, drupalgap_entity_render_field tries to pick up entity.language from the entity object, if body has that langugage then it uses it. If not it falls back to 'und'. Ideally should we not first check to see if the apps default language content is present or not? Im working on a multilingual app and this seemed a bug to me.

If this patch makes sense, could you please have it merged?

Thanks in advance.

Cheers,
 -Vijay
