### PR TITLE
Logo image shouldnt spill beyond parent div

### DIFF
--- a/drupalgap.css
+++ b/drupalgap.css
@@ -99,6 +99,7 @@ div.messages ul li {
 
 /* Don't let images stretch out of their parent container in the main content div */ 
 div[role="main"] img,
+div[role="banner"] img,
 #_drupalgap_splash_content img {
   width: auto !important; 
   width: 100%;


### PR DESCRIPTION
Hi Tyler,

Could you please review this patch and merge if you feel its worth it. I ve noticed that too big images get rendered beyond the parent div in the logo. We should address this the same way we do for role=main divs. This impacts devices with different resolutions.

Thanks in advance.

Cheers,
 -Vijay
