### PR TITLE
Save multiple back paths to avoid invalid work of drupalgap_path_get()

### DIFF
--- a/src/drupalgap.js
+++ b/src/drupalgap.js
@@ -37,7 +37,7 @@ function drupalgap_init() {
       destination: '',
       api: {},
       back: false, /* moving backwards or not */
-      back_path: '', /* the path to move back to */
+      back_path: [], /* paths to move back to */
       blocks: [],
       content_types_list: {}, /* holds info about each content type */
       date_formats: { }, /* @see system_get_date_formats() in Drupal core */

--- a/src/includes/common.inc.js
+++ b/src/includes/common.inc.js
@@ -320,7 +320,7 @@ function _drupalgap_back() {
   try {
     drupalgap.back = true;
     history.back();
-    drupalgap_path_set(drupalgap.back_path);
+    drupalgap_path_set(drupalgap.back_path.pop());
   }
   catch (error) { console.log('drupalgap_back' + error); }
 }
@@ -452,7 +452,7 @@ function drupalgap_goto(path) {
     }
 
     // Save the back path.
-    drupalgap.back_path = drupalgap_path_get();
+    drupalgap.back_path.push(drupalgap_path_get());
 
     // Set the current menu path to the path input.
     drupalgap_path_set(path);


### PR DESCRIPTION
In case with nesting detail pages it is useful to call drupalgap_back() to return to the previous level. For example, "list page" -> "detail page" -> "comments page". 
If back_path is a string, it stores only one step back. So, in above case returning to "list page" will produce invalid drupalgap_path_get() behavior. And, for example, if we try to authorize, our current page will be removed by  drupalgap_remove_pages_from_dom();
