### PR TITLE
Fixed drupalgap_file_exists

### DIFF
--- a/src/dg.js
+++ b/src/dg.js
@@ -633,6 +633,7 @@ function drupalgap_file_exists(path) {
     jQuery.ajax({
       async: false,
       type: 'HEAD',
+      dataType: 'text',
       url: path,
       success: function() { file_exists = true; },
       error: function(xhr, textStatus, errorThrown) { }


### PR DESCRIPTION
Function `drupalgap_file_exists` didn't work anymore with jquery 1.9 if requested file was of json type.
This fixes.
