### PR TITLE
Variable _empty added to theme_view

### DIFF
--- a/src/includes/views.inc.js
+++ b/src/includes/views.inc.js
@@ -35,6 +35,10 @@ dg.theme_view = function(variables) {
           content += open + variables._row_callback(data.results[i]) + close;
         }
       }
+      else if (variables._empty) {
+        if (typeof variables._empty === 'object') { content += dg.render(variables._empty); }
+        else { content += '<div class="view-empty">' + variables._empty + '</div>'; };
+      }
       content += '</' + format + '>';
       ok({
         variables: variables,


### PR DESCRIPTION
If the view returns nothing, we can add custom content with this new variable.
Since the "Rest export" display type does not use D8 native empty plugins, I thought it would be useful.
