### PR TITLE
Add prefix/suffix for theme_view results

### DIFF
--- a/src/includes/views.inc.js
+++ b/src/includes/views.inc.js
@@ -34,6 +34,11 @@ dg.theme_view = function(variables) {
           }
           content += open + variables._row_callback(data.results[i]) + close;
         }
+        var contentPrefix = variables._contentPrefix ? variables._contentPrefix : '';
+        var contentSuffix = variables._contentSuffix ? variables._contentSuffix : '';
+        if (typeof contentPrefix === 'object') { contentPrefix = dg.render(contentPrefix); }
+        if (typeof contentSuffix === 'object') { contentSuffix = dg.render(contentSuffix); }
+        content = contentPrefix + content + contentSuffix;
       }
       content += '</' + format + '>';
       ok({


### PR DESCRIPTION
You can already add a _suffix and _prefix for most themes, but in a view case, I think it's relevant to add the same feature only when the view results is not empty. 

For example, lets say you want to add viewB on top of viewA, but only if viewA outputs something.
