### PR TITLE
Add post Promise functions

### DIFF
--- a/src/includes/theme.inc.js
+++ b/src/includes/theme.inc.js
@@ -74,7 +74,7 @@ dg.theme = function(hook, variables) {
     if (html instanceof Promise) {
       html.then(function(data) {
         document.getElementById(data.variables._attributes.id).innerHTML = dg.render(data.content);
-        if (data.variables._callback.length) {
+        if (typeof data.variables._callback !== 'undefined' && data.variables._callback.length) {
           for (var i = 0; i < data.variables._callback.length; i++) { data.variables._callback[i](data); }
           data.variables._callback = [];
         }

--- a/src/includes/theme.inc.js
+++ b/src/includes/theme.inc.js
@@ -74,6 +74,10 @@ dg.theme = function(hook, variables) {
     if (html instanceof Promise) {
       html.then(function(data) {
         document.getElementById(data.variables._attributes.id).innerHTML = dg.render(data.content);
+        if (data.variables._callback.length) {
+          for (var i = 0; i < data.variables._callback.length; i++) { data.variables._callback[i](); }
+          data.variables._callback = [];
+        }
       });
       return '<div ' + dg.attributes(variables._attributes) + '></div>';
     }

--- a/src/includes/theme.inc.js
+++ b/src/includes/theme.inc.js
@@ -75,7 +75,7 @@ dg.theme = function(hook, variables) {
       html.then(function(data) {
         document.getElementById(data.variables._attributes.id).innerHTML = dg.render(data.content);
         if (data.variables._callback.length) {
-          for (var i = 0; i < data.variables._callback.length; i++) { data.variables._callback[i](); }
+          for (var i = 0; i < data.variables._callback.length; i++) { data.variables._callback[i](data); }
           data.variables._callback = [];
         }
       });


### PR DESCRIPTION
Currently, there's a global postRender process and it works like a charm. But I think there's missing something; a postRender for Promises as a callback.

To justify this proposition, here's a case

Lets say we have an "AddToCalendar" link inside each views row. 
So when we call theme_view, theres nothing we can do to add an event on each links.
Global postRender is of course triggered before the view query. If jQuery is installed, we could add the ".on()" function on body, but it's not really interesting since my solution solves that problem.

What do you think?
