### PR TITLE
Scroll top when app's div content is updated

### DIFF
--- a/src/includes/render.inc.js
+++ b/src/includes/render.inc.js
@@ -55,6 +55,7 @@ dg.appRender = function(content) {
 
       // Place the region, and block placeholders, into the app's div.
       document.getElementById('dg-app').innerHTML = innerHTML;
+      window.scrollTo(0,0);
 
       // Run the build promise for each block, then inject their content as they respond.
       // Keep a tally of all the blocks, and once their promises have all completed, then


### PR DESCRIPTION
When I'm switching from routes to routes, I notice that the scroll is kept for some reason. 
I propose here to force it to go "back to top" each time a new render is triggered. This is a simple suggestion, I just found it interesting and less frustrating as a mobile user. It could also be interesting to activate this feature in a setting.
