### PR TITLE
route from external page

### DIFF
--- a/app/default.settings.js
+++ b/app/default.settings.js
@@ -117,6 +117,14 @@ drupalgap.settings.locale = {
 drupalgap.settings.title = 'DrupalGap';
  
 // App Front Page
+
+// uncomment below and change drupalgap.settings.front to = landingPage; to route to expected page if coming from external site
+//var landingPage = 'dashboard';
+//if(location.hash){
+//  goToPage = location.hash.replace("#","");
+//    homePage = goToPage.replace('node_', 'node/');
+//}
+
 drupalgap.settings.front = 'dashboard';
 
 // Theme

--- a/src/includes/go.inc.js
+++ b/src/includes/go.inc.js
@@ -360,6 +360,10 @@ function drupalgap_back() {
       });
     }
     else if (active_page_id == '_drupalgap_splash') { return; }
+    else if (drupalgap.back_path == ''){
+      drupalgap_goto(drupal.settings.front);
+      return;
+    }        
     else { _drupalgap_back(); }
   }
   catch (error) { console.log('drupalgap_back - ' + error); }


### PR DESCRIPTION
I needed to be able to route people to a landing page if they were linked from an external site, this broke the back button functionality. See fix for that in go.inc.js, which may help other edge cases of drupalgap_back() sending to a blank or splash screen.
