### PR TITLE
Correct Error Log Function Name

### DIFF
--- a/src/includes/form.load.inc.js
+++ b/src/includes/form.load.inc.js
@@ -174,5 +174,5 @@ function _drupalgap_form_load_set_element_defaults(form, language) {
       }
     }
   }
-  catch (error) { console.log('_drupalgap_form_elements_set_defaults - ' + error); }
+  catch (error) { console.log('_drupalgap_form_load_set_element_defaults - ' + error); }
 }


### PR DESCRIPTION
Correct Error Log Function Name - _drupalgap_form_load_set_element_defaults