### PR TITLE
dg.alert not in drupalgap.min.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@ var drupalgap_grunt_src = [
   'src/includes/field-widget.inc.js',
 
   'src/includes/go.inc.js',
+  'src/includes/dialogs.inc.js',
   'src/includes/messages.inc.js',
   'src/includes/module.inc.js',
   'src/includes/region.inc.js',


### PR DESCRIPTION
This causes problems with form submissions as it uses this for the validate output.