### PR TITLE
Remove api.js from binaries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,8 @@ var drupalgap_grunt_src = [
   'src/*.js',
   'src/includes/*.inc.js',
   'src/includes/form/form.*.js',
-  'src/modules/*/*.js'
+  'src/modules/*/*.js',
+  '!src/modules/api/**'
 ];
 var drupalgap_grunt_min_src = [
   'src/*.js',


### PR DESCRIPTION
This is a followup to #848.

The API documentation appears to get its information directly from `src/` as it should, so I don't expect this change to affect that.