### PR TITLE
Fix placeholder access arguments that do not map to objects

### DIFF
--- a/src/dg.js
+++ b/src/dg.js
@@ -1112,7 +1112,7 @@ function drupalgap_menu_access(routerPath, path) {
             else {
               // Replace any integer arguments with the corresponding path argument.
               for (var i = 0; i < access_arguments.length; i++) {
-                if (is_int(access_arguments[i])) { access_arguments[i] = arg(i, path); }
+                if (is_int(access_arguments[i])) { access_arguments[i] = arg(access_arguments[i], path); }
               }
             }
             return fn.apply(null, Array.prototype.slice.call(access_arguments));


### PR DESCRIPTION
When a placeholder access argument maps to a loaded object the list of access arguments at position `index` gets replaced with the loaded object. However, when there's no entity and a specific path component is chosen by number in access_arguments, the number indicating the path component is ignored, only the the index of the number in the list of access arguments is used.

This pull request fixes that by calling `arg()` with the number specified rather than position of the number.