### PR TITLE
Use node_access() for node/add/% access_callback

### DIFF
--- a/src/modules/node/node.js
+++ b/src/modules/node/node.js
@@ -148,6 +148,8 @@ function node_menu() {
         title_arguments: [2],
         page_callback: 'node_add_page_by_type',
         page_arguments: [2],
+        access_callback: 'node_access',
+        access_arguments: ['create', 2],
         options: { reloadPage: true }
       },
       'node/%': {


### PR DESCRIPTION
This is blocked by https://github.com/signalpoint/DrupalGap/pull/1002.
If that pull request is accepted then it might make sense to use `node_access()` more.